### PR TITLE
Use as Library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,182 @@
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate clap;
+
+use clap::{App, AppSettings, Arg, Shell, SubCommand};
+use image::Luma;
+use qrcode;
+use qrcode::{EcLevel, QrCode};
+use std::fs;
+use std::io::prelude::*;
+use std::process::exit;
+use term;
+use term::color;
+
+mod payloads;
+
+pub const WIFI_COMMAND: &str = "wifi";
+pub const MAIL_COMMAND: &str = "mail";
+pub const SMS_COMMAND: &str = "sms";
+pub const MMS_COMMAND: &str = "mms";
+pub const GEO_COMMAND: &str = "geo";
+pub const PHONE_COMMAND: &str = "phone";
+pub const SKYPE_COMMAND: &str = "skype";
+pub const WHATSAPP_COMMAND: &str = "whatsapp";
+pub const URL_COMMAND: &str = "url";
+pub const BOOKMARK_COMMAND: &str = "bookmark";
+pub const BITCOIN_COMMAND: &str = "bitcoin";
+// const GIRO_COMMAND: &'static str = "giro";
+// const CALENDAR_COMMAND: &'static str = "calendar";
+// const CONTACT_COMMAND: &'static str = "contact";
+
+#[derive(Debug)]
+pub struct Parameters {
+    pub safe_zone: bool,
+    pub output: String,
+    pub payload: String,
+    pub error: EcLevel,
+    pub input: String,
+    pub completions: Completions,
+    pub command: String,
+}
+
+impl Parameters {
+    pub fn new() -> Parameters {
+        Parameters {
+            safe_zone: false,
+            output: "".to_string(),
+            payload: "".to_string(),
+            error: EcLevel::H,
+            input: "".to_string(),
+            completions: Completions::new(),
+            command: "".to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Completions {
+    pub comp_dir: String,
+    pub shell: String,
+}
+impl Completions {
+    pub fn new() -> Completions {
+        Completions {
+            comp_dir: "".to_string(),
+            shell: "".to_string(),
+        }
+    }
+}
+
+/*TODO: add arguments for:
+- Add help texts for the subcommands
+- Add error texts for some exit branches (mostly file output and qrcode gen)
+- implement different types of qr payloads
+- write unit tests for the payloads
+- write integration tests for edge case inputs
+*/
+pub fn generate(data: &Parameters) {
+    //TODO: catch the possible errors
+    let code = QrCode::with_error_correction_level(&data.payload, data.error).unwrap();
+
+    // are we drawing to the terminal or to a file?
+    if data.output.len() == 1 {
+        save(&code, data.safe_zone, &data.output);
+    } else {
+        draw(&code, data.safe_zone)
+    }
+
+    // shall we also print the payload to the screen?
+    if data.payload.len() > 0 {
+        println!("{:?}", data.payload);
+    }
+}
+
+// save to a file at the path
+fn save(code: &QrCode, safe: bool, path: &str) {
+    // render to a image struct
+    let image = code.render::<Luma<u8>>().quiet_zone(safe).build();
+
+    // save the image
+    match image.save(path) {
+        Ok(..) => println!("Image successfully saved to: {:?}", path),
+        Err(e) => println!(
+            "Tried to create file but there was a problem: {:?}",
+            if let Some(inner_err) = e.get_ref() {
+                inner_err.to_string()
+            } else {
+                e.to_string()
+            }
+        ),
+    };
+}
+
+// draw to the terminal
+fn draw(code: &QrCode, safe: bool) {
+    // get "bit" array
+    let bit_array = code.to_colors();
+
+    // get the terminal output pipe
+    let mut t = term::stdout().unwrap();
+
+    // get the code width and add extra space for the safe zone
+    let w = code.width();
+    let wide = w + 6;
+
+    // draw the first white safe zone
+    if safe {
+        for a in 1..(wide * 3) + 1 {
+            t.bg(color::BRIGHT_WHITE).unwrap();
+            write!(t, "  ").unwrap();
+            if a % wide == 0 {
+                t.reset().unwrap();
+                writeln!(t, "").unwrap();
+            }
+        }
+    }
+
+    // main drawing loop
+    for (i, item) in bit_array.iter().enumerate() {
+        // left safe zone
+        if safe && i % w == 0 {
+            t.bg(color::BRIGHT_WHITE).unwrap();
+            write!(t, "      ").unwrap();
+        }
+
+        // draw black or white blocks
+        if *item == qrcode::Color::Dark {
+            t.bg(color::BLACK).unwrap();
+            write!(t, "  ").unwrap();
+        } else {
+            t.bg(color::BRIGHT_WHITE).unwrap();
+            write!(t, "  ").unwrap();
+        }
+
+        if (i + 1) % w == 0 {
+            if safe {
+                // draw right safe zone
+                t.bg(color::BRIGHT_WHITE).unwrap();
+                write!(t, "      ").unwrap();
+            }
+            t.reset().unwrap();
+            writeln!(t, "").unwrap();
+        }
+    }
+
+    // draw the last white safe zone
+    if safe {
+        for a in 1..(wide * 3) + 1 {
+            t.bg(color::BRIGHT_WHITE).unwrap();
+            write!(t, "  ").unwrap();
+            if a % wide == 0 {
+                t.reset().unwrap();
+                writeln!(t, "").unwrap();
+            }
+        }
+    }
+
+    // reset to normal color and flush write buffer
+    t.reset().unwrap();
+    t.flush().unwrap();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
         None => "".to_string(),
     };
 
-    qrterm::generate(&params);
+    params.generate();
 }
 
 // deduces wich kind of string we are going to encode

--- a/src/payloads.rs
+++ b/src/payloads.rs
@@ -24,10 +24,7 @@ pub fn wifi_string(ssid: &str, password: &str, mode: &Authentication, is_hidden:
 
     return format!(
         "WIFI:T:{:?};S:{};P:{};{};",
-        mode,
-        ssid_n,
-        password_n,
-        hidden
+        mode, ssid_n, password_n, hidden
     );
 }
 
@@ -46,30 +43,24 @@ pub fn mail_string(
     encoding: &MailEncoding,
 ) -> String {
     match *encoding {
-        MailEncoding::MAILTO => {
-            format!(
-                "mailto:{}?subject={}&body={}",
-                receiver,
-                uri_escape(subject),
-                uri_escape(message)
-            )
-        }
-        MailEncoding::MATMSG => {
-            format!(
-                "MATMSG:TO:{};SUB:{};BODY:{};;",
-                receiver,
-                escape_input(subject, false),
-                escape_input(message, false)
-            )
-        }
-        MailEncoding::SMTP => {
-            format!(
-                "SMTP:{}:{}:{}",
-                receiver,
-                escape_input(subject, true),
-                escape_input(message, true)
-            )
-        }
+        MailEncoding::MAILTO => format!(
+            "mailto:{}?subject={}&body={}",
+            receiver,
+            uri_escape(subject),
+            uri_escape(message)
+        ),
+        MailEncoding::MATMSG => format!(
+            "MATMSG:TO:{};SUB:{};BODY:{};;",
+            receiver,
+            escape_input(subject, false),
+            escape_input(message, false)
+        ),
+        MailEncoding::SMTP => format!(
+            "SMTP:{}:{}:{}",
+            receiver,
+            escape_input(subject, true),
+            escape_input(message, true)
+        ),
     }
 }
 


### PR DESCRIPTION
Moved the code into `lib.rs` so that it can be used as a library by other applications that may want to generate QR codes from the command line.

I haven't done anything extra (no extra tests, nothing). Simply moved the code. I also moved the `generate` function to an `impl` of a `struct`.

I've left `main.rs` "as is" so that it can still be used from the cli, it just imports `lib.rs`.

I haven't published this is a crate, thought I'd leave that up to you.